### PR TITLE
c-list: add c_list_init()

### DIFF
--- a/src/c-list.h
+++ b/src/c-list.h
@@ -48,6 +48,14 @@ struct CList {
 #define C_LIST_INIT(_var) { .next = &(_var), .prev = &(_var) }
 
 /**
+ * c_list_init() - initialize list entry
+ * @what:               list entry to initialize
+ */
+static inline void c_list_init(CList *what) {
+        *what = (CList)C_LIST_INIT(*what);
+}
+
+/**
  * c_list_entry() - get parent container of list entry
  * @_what:              list entry, or NULL
  * @_t:                 type of parent container


### PR DESCRIPTION
Add c_list_init() to initialize a CList instance.
For example:

    c_list_init(&obj->list);

as a shorthand for the form

    obj->list = (CList)C_LIST_INIT(&obj->list);



Is this left out intentionally to keep the API small? IMHO this short-hand would be nice, as the alternative is rather verbose.
Maybe return "void"? Dunno.