### PR TITLE
c-list: add "c-list-fwd.h" to declare CList structure alone

### DIFF
--- a/src/c-list-fwd.h
+++ b/src/c-list-fwd.h
@@ -1,0 +1,28 @@
+#pragma once
+
+/*
+ * Circular Double Linked List Implementation in Standard ISO-C11
+ *
+ * Header to declare CList structure.
+ */
+
+#ifndef _C_LIST_DEFINED
+
+#define _C_LIST_DEFINED
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct CList CList;
+
+struct CList {
+        CList *next;
+        CList *prev;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/c-list.h
+++ b/src/c-list.h
@@ -23,6 +23,9 @@ extern "C" {
 
 #include <stddef.h>
 
+#ifndef _C_LIST_DEFINED
+#define _C_LIST_DEFINED
+
 typedef struct CList CList;
 
 /**
@@ -44,6 +47,8 @@ struct CList {
         CList *next;
         CList *prev;
 };
+
+#endif
 
 #define C_LIST_INIT(_var) { .next = &(_var), .prev = &(_var) }
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,7 +4,7 @@
 #  future, if we add more complex list helpers.)
 #
 
-install_headers('c-list.h')
+install_headers(['c-list.h', 'c-list-fwd.h'])
 
 libclist_dep = declare_dependency(
         include_directories: include_directories('.'),

--- a/src/test-api.c
+++ b/src/test-api.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "c-list-fwd.h"
 #include "c-list.h"
 
 typedef struct {

--- a/src/test-embed.c
+++ b/src/test-embed.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "c-list.h"
+#include "c-list-fwd.h"
 
 typedef struct Entry Entry;
 


### PR DESCRIPTION
CList commonly needs to be embedded as non-opaque type in the
linked structures. Add "c-list-fwd.h" header to declare CList
without the list operations.

Signed-off-by: Thomas Haller <thaller@redhat.com>