### PR TITLE
Fix assignment instead of comparison

### DIFF
--- a/src/test-basic.c
+++ b/src/test-basic.c
@@ -125,15 +125,15 @@ static void test_swap(void) {
 
         assert(c_list_first(&list1) == &list);
         assert(c_list_last(&list1) == &list);
-        assert(list.next = &list1);
-        assert(list.prev = &list1);
+        assert(list.next == &list1);
+        assert(list.prev == &list1);
 
         c_list_swap(&list1, &list2);
 
         assert(c_list_first(&list2) == &list);
         assert(c_list_last(&list2) == &list);
-        assert(list.next = &list2);
-        assert(list.prev = &list2);
+        assert(list.next == &list2);
+        assert(list.prev == &list2);
 
         assert(list1.prev == list1.next && list1.prev == &list1);
 }


### PR DESCRIPTION
../subprojects/c-list/src/test-basic.c: In function ‘test_swap’:
../subprojects/c-list/src/test-basic.c:128:16: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
  128 |         assert(list.next = &list1);
      |                ^~~~
../subprojects/c-list/src/test-basic.c:129:16: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
  129 |         assert(list.prev = &list1);
      |                ^~~~
../subprojects/c-list/src/test-basic.c:135:16: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
  135 |         assert(list.next = &list2);
      |                ^~~~
../subprojects/c-list/src/test-basic.c:136:16: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
  136 |         assert(list.prev = &list2);
      |                ^~~~

Signed-off-by: Lucas De Marchi <lucas.de.marchi@gmail.com>