### PR TITLE
Avoid GNU extension, increase warning level

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,7 @@ project(
         license: 'Apache',
         default_options: [
                 'c_std=c11',
+                'warning_level=3',
         ],
 )
 project_description = 'Circular Intrusive Double Linked List Collection'

--- a/src/c-list.h
+++ b/src/c-list.h
@@ -70,7 +70,8 @@ static inline void c_list_init(CList *what) {
  * Return: Pointer to parent container, or NULL.
  */
 #define c_list_entry(_what, _t, _m) \
-        ((_t *)(void *)(((unsigned long)(void *)(_what) ?: \
+        ((_t *)(void *)(((unsigned long)(void *)(_what) ?                       \
+                         (unsigned long)(void *)(_what) :                       \
                          offsetof(_t, _m)) - offsetof(_t, _m)))
 
 /**

--- a/src/test-api.c
+++ b/src/test-api.c
@@ -104,7 +104,7 @@ static void test_api(void) {
         assert(!c_list_last_entry(&list, Node, link));
 }
 
-int main(int argc, char **argv) {
+int main(void) {
         test_api();
         return 0;
 }

--- a/src/test-basic.c
+++ b/src/test-basic.c
@@ -176,7 +176,7 @@ static void test_flush(void) {
         assert(!c_list_is_linked(&e2));
 }
 
-int main(int argc, char **argv) {
+int main(void) {
         test_iterators();
         test_swap();
         test_splice();

--- a/src/test-embed.c
+++ b/src/test-embed.c
@@ -103,7 +103,7 @@ static void test_entry(void) {
         assert(!c_list_is_linked(&e4.link));
 }
 
-int main(int argc, char **argv) {
+int main(void) {
         test_entry();
         return 0;
 }


### PR DESCRIPTION
- It avoids compiler extension: [6.8 Conditionals with Omitted Operands](https://gcc.gnu.org/onlinedocs/gcc/Conditionals.html)
- Increase warning level to 3
- Fix the resulting warnings



