### PR TITLE
c-list: add c_list_split() functionality

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # c-list - Circular Intrusive Double Linked List Collection
 
 ## CHANGES WITH 3:
+        * API: add c_list_split() defined as inverse of c_list_splice()
+
+## CHANGES WITH 3:
 
         * API break: The c_list_loop_*() symbols were removed, since we saw
                      little use for them. No user was known at the time, so

--- a/src/c-list.h
+++ b/src/c-list.h
@@ -260,6 +260,29 @@ static inline void c_list_splice(CList *target, CList *source) {
 }
 
 /**
+ * c_list_split() - split one list in two
+ * @list:       the list to split into
+ * @where:      new starting element of newlist
+ * @newlist:    new list
+ *
+ * This split list 'list' in two list. The second start from 'where'.
+ * This function is the inverse of c_list_splice
+ *
+ * 'where' has to be included in 'list' and so where is by definition not empty
+ */
+static inline void c_list_split(CList *list, CList *where, CList *newlist) {
+    newlist->next = where;
+    newlist->prev = list->prev;
+
+    newlist->prev->next = newlist;
+    newlist->next->prev->next = list;
+
+    list->prev = newlist->next->prev;
+    newlist->next->prev = newlist;
+}
+
+
+/**
  * c_list_first() - return pointer to first element, or NULL if empty
  * @list:               list to operate on, or NULL
  *

--- a/src/test-basic.c
+++ b/src/test-basic.c
@@ -158,6 +158,55 @@ static void test_splice(void) {
         assert(c_list_last(&target) == &e2);
 }
 
+static void test_split(void) {
+        CList target;
+        CList source;
+        CList newlist;
+        CList e1, e2;
+
+        // test1
+
+        c_list_init(&target);
+        c_list_init(&source);
+
+        c_list_link_tail(&source, &e1);
+
+        assert(c_list_is_empty(&target));
+        c_list_splice(&target, &source);
+        assert(c_list_first(&target) == &e1);
+        assert(c_list_last(&target) == &e1);
+        assert(c_list_is_empty(&source));
+
+        c_list_split(&target, &e1, &newlist);
+        assert(c_list_first(&newlist) == &e1);
+        assert(c_list_last(&newlist) == &e1);
+        assert(c_list_is_empty(&target));
+
+        // test2
+
+        c_list_init(&target);
+        c_list_init(&source);
+
+        c_list_link_tail(&source, &e1);
+        c_list_link_tail(&target, &e2);
+
+        assert(c_list_first(&source) == &e1);
+        assert(c_list_last(&source) == &e1);
+        assert(c_list_first(&target) == &e2);
+        assert(c_list_last(&target) == &e2);
+        c_list_splice(&target, &source);
+        assert(c_list_first(&target) == &e2);
+        assert(c_list_last(&target) == &e1);
+        assert(c_list_is_empty(&source));
+
+        c_list_split(&target, &e1, &newlist);
+        assert(c_list_first(&newlist) == &e1);
+        assert(c_list_last(&newlist) == &e1);
+        assert(c_list_first(&target) == &e2);
+        assert(c_list_last(&target) == &e2);
+}
+
+
 static void test_flush(void) {
         CList e1 = C_LIST_INIT(e1), e2 = C_LIST_INIT(e2);
         CList list1 = C_LIST_INIT(list1), list2 = C_LIST_INIT(list2);
@@ -220,6 +269,7 @@ int main(void) {
         test_iterators();
         test_swap();
         test_splice();
+        test_split();
         test_flush();
         test_macros();
         test_gnu();


### PR DESCRIPTION
the new functionality to split a list in 2 works as reverse of c_list_splice()