### PR TITLE
c-list: add reverse iterators

### DIFF
--- a/src/test-api.c
+++ b/src/test-api.c
@@ -86,7 +86,13 @@ static void test_api(void) {
         c_list_for_each(list_iter, &list)
                 assert(list_iter != &list);
 
+        c_list_for_each_reverse(list_iter, &list)
+                assert(list_iter != &list);
+
         c_list_for_each_safe(list_iter, list_safe, &list)
+                assert(list_iter != &list);
+
+        c_list_for_each_safe_reverse(list_iter, list_safe, &list)
                 assert(list_iter != &list);
 
         list_iter = NULL;
@@ -94,10 +100,21 @@ static void test_api(void) {
                 assert(list_iter != &list);
 
         list_iter = NULL;
+        c_list_for_each_continue_reverse(list_iter, &list)
+                assert(list_iter != &list);
+
+        list_iter = NULL;
         c_list_for_each_safe_continue(list_iter, list_safe, &list)
                 assert(list_iter != &list);
 
+        list_iter = NULL;
+        c_list_for_each_safe_continue_reverse(list_iter, list_safe, &list)
+                assert(list_iter != &list);
+
         c_list_for_each_safe_unlink(list_iter, list_safe, &list)
+                assert(list_iter != &list);
+
+        c_list_for_each_safe_unlink_reverse(list_iter, list_safe, &list)
                 assert(list_iter != &list);
 
         /* list accessors */
@@ -132,13 +149,41 @@ static void test_api_gnu(void) {
         c_list_for_each_entry_safe_unlink(node_iter, node_safe, &list, link)
                 assert(&node_iter->link != &list);
 }
+
+static void test_api_gnu_reverse(void) {
+        CList list = C_LIST_INIT(list);
+        Node *node_iter, *node_safe;
+
+        /* c_list_entry() based iterators */
+
+        c_list_for_each_entry_reverse(node_iter, &list, link)
+                assert(&node_iter->link != &list);
+
+        c_list_for_each_entry_safe_reverse(node_iter, node_safe, &list, link)
+                assert(&node_iter->link != &list);
+
+        node_iter = NULL;
+        c_list_for_each_entry_continue_reverse(node_iter, &list, link)
+                assert(&node_iter->link != &list);
+
+        node_iter = NULL;
+        c_list_for_each_entry_safe_continue_reverse(node_iter, node_safe, &list, link)
+                assert(&node_iter->link != &list);
+
+        c_list_for_each_entry_safe_unlink_reverse(node_iter, node_safe, &list, link)
+                assert(&node_iter->link != &list);
+}
 #else
 static void test_api_gnu(void) {
+}
+
+static void test_api_gnu_reverse(void) {
 }
 #endif
 
 int main(void) {
         test_api();
         test_api_gnu();
+        test_api_gnu_reverse();
         return 0;
 }

--- a/src/test-embed.c
+++ b/src/test-embed.c
@@ -57,6 +57,17 @@ static void test_entry(void) {
         }
         assert(i == 2);
 
+        i = 0;
+        c_list_for_each_reverse(iter, &list) {
+                e = c_list_entry(iter, Entry, link);
+                assert(i != 0 || e == &e2);
+                assert(i != 1 || e == &e1);
+                assert(i < 2);
+                ++i;
+        }
+        assert(i == 2);
+
+
         /* link 2 more entries */
 
         c_list_link_tail(&list, &e3.link);
@@ -79,6 +90,18 @@ static void test_entry(void) {
         }
         assert(i == 4);
 
+        i = 0;
+        c_list_for_each_reverse(iter, &list) {
+                e = c_list_entry(iter, Entry, link);
+                assert(i != 0 || e == &e4);
+                assert(i != 1 || e == &e3);
+                assert(i != 2 || e == &e2);
+                assert(i != 3 || e == &e1);
+                assert(i < 4);
+                ++i;
+        }
+        assert(i == 4);
+
         assert(!c_list_is_empty(&list));
         assert(c_list_is_linked(&e1.link));
         assert(c_list_is_linked(&e2.link));
@@ -94,6 +117,38 @@ static void test_entry(void) {
                 assert(i != 1 || e == &e2);
                 assert(i != 2 || e == &e3);
                 assert(i != 3 || e == &e4);
+                assert(i < 4);
+                ++i;
+                c_list_unlink(&e->link);
+        }
+        assert(i == 4);
+
+        assert(c_list_is_empty(&list));
+        assert(!c_list_is_linked(&e1.link));
+        assert(!c_list_is_linked(&e2.link));
+        assert(!c_list_is_linked(&e3.link));
+        assert(!c_list_is_linked(&e4.link));
+
+        /* remove via safe iterator in reverse */
+
+        c_list_link_tail(&list, &e1.link);
+        c_list_link_tail(&list, &e2.link);
+        c_list_link_tail(&list, &e3.link);
+        c_list_link_tail(&list, &e4.link);
+
+        assert(!c_list_is_empty(&list));
+        assert(c_list_is_linked(&e1.link));
+        assert(c_list_is_linked(&e2.link));
+        assert(c_list_is_linked(&e3.link));
+        assert(c_list_is_linked(&e4.link));
+
+        i = 0;
+        c_list_for_each_safe_reverse(iter, safe, &list) {
+                e = c_list_entry(iter, Entry, link);
+                assert(i != 0 || e == &e4);
+                assert(i != 1 || e == &e3);
+                assert(i != 2 || e == &e2);
+                assert(i != 3 || e == &e1);
                 assert(i < 4);
                 ++i;
                 c_list_unlink(&e->link);
@@ -135,6 +190,17 @@ static void test_entry_gnu(void) {
         }
         assert(i == 4);
 
+        i = 0;
+        c_list_for_each_entry_reverse(e, &list, link) {
+                assert(i != 0 || e == &e4);
+                assert(i != 1 || e == &e3);
+                assert(i != 2 || e == &e2);
+                assert(i != 3 || e == &e1);
+                assert(i < 4);
+                ++i;
+        }
+        assert(i == 4);
+
         assert(!c_list_is_empty(&list));
         assert(c_list_is_linked(&e1.link));
         assert(c_list_is_linked(&e2.link));
@@ -149,6 +215,37 @@ static void test_entry_gnu(void) {
                 assert(i != 1 || e == &e2);
                 assert(i != 2 || e == &e3);
                 assert(i != 3 || e == &e4);
+                assert(i < 4);
+                ++i;
+                c_list_unlink(&e->link);
+        }
+        assert(i == 4);
+
+        assert(c_list_is_empty(&list));
+        assert(!c_list_is_linked(&e1.link));
+        assert(!c_list_is_linked(&e2.link));
+        assert(!c_list_is_linked(&e3.link));
+        assert(!c_list_is_linked(&e4.link));
+
+        /* remove via safe iterator in reverse */
+
+        c_list_link_tail(&list, &e1.link);
+        c_list_link_tail(&list, &e2.link);
+        c_list_link_tail(&list, &e3.link);
+        c_list_link_tail(&list, &e4.link);
+
+        assert(!c_list_is_empty(&list));
+        assert(c_list_is_linked(&e1.link));
+        assert(c_list_is_linked(&e2.link));
+        assert(c_list_is_linked(&e3.link));
+        assert(c_list_is_linked(&e4.link));
+
+        i = 0;
+        c_list_for_each_entry_safe_reverse(e, safe, &list, link) {
+                assert(i != 0 || e == &e4);
+                assert(i != 1 || e == &e3);
+                assert(i != 2 || e == &e2);
+                assert(i != 3 || e == &e1);
                 assert(i < 4);
                 ++i;
                 c_list_unlink(&e->link);


### PR DESCRIPTION
This PR adds reverse versions of each `for_each` macro, allowing for reverse iteration of lists.

This is one feature we wanted in a list implementation and which isn't currently implemented by the library.